### PR TITLE
fixed input screen bug and color bug

### DIFF
--- a/src/main/java/com/houarizegai/calculator/ui/CalculatorUI.java
+++ b/src/main/java/com/houarizegai/calculator/ui/CalculatorUI.java
@@ -117,7 +117,7 @@ public class CalculatorUI {
 
     private void initInputScreen(int[] columns, int[] rows) {
         inputScreen = new JTextField("0");
-        inputScreen.setBounds(columns[0], rows[0], 350, 70);
+        inputScreen.setBounds(columns[0], rows[0], 700, 70);
         inputScreen.setEditable(false);
         inputScreen.setBackground(Color.WHITE);
         inputScreen.setFont(new Font(FONT_NAME, Font.PLAIN, 33));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ themes:
     textColor: 000000
     operatorBackground: f7f9fc
     numbersBackground: ffffff
-    btnEqualTextColor: ffffff
+    btnEqualTextColor: 000000
     btnEqualBackground: 0067c0
   - name: Dark
     applicationBackground: 1c2028


### PR DESCRIPTION
When doing computations such as 2.2 * 0.2 part of the answer would appear off the screen. Bug now fixed.  Also on light mode equals button was not visible as it was set to white. Changed the .yaml file to fix this bug.