### PR TITLE
Fix bug #168: correct theme display on macOS

### DIFF
--- a/src/main/java/com/houarizegai/calculator/App.java
+++ b/src/main/java/com/houarizegai/calculator/App.java
@@ -1,10 +1,17 @@
 package com.houarizegai.calculator;
 
 import com.houarizegai.calculator.ui.CalculatorUI;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 public class App {
 
     public static void main(String[] args) {
+        try {
+          UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException e) {
+          e.printStackTrace();
+        }
         new CalculatorUI();
     }
 }


### PR DESCRIPTION
Use getCrossPlatformLookAndFeelClassName() to force cross-platform styles instead of macOS system styles.  This avoids system style restrictions on button appearance.